### PR TITLE
fixed: href of link to pathogen

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -57,7 +57,7 @@ is exactly what I wanted, but generalized.
 ## Installation
 
 If you don't have a preferred installation method, I recommend installing
-[pathogen.vim](https://github.com/frioux/vim-lost), and then simply copy and
+[pathogen.vim](https://github.com/tpope/vim-pathogen), and then simply copy and
 paste:
 
     cd ~/.vim/bundle


### PR DESCRIPTION
The link for pathogen linked to vim-lost's own repo, fixed to point to the correct github repo.